### PR TITLE
Fix regression of .ToUpper() from 81b55b7 (Speed & memory utilization improvements)

### DIFF
--- a/WC3MapDeprotector/Deprotector.cs
+++ b/WC3MapDeprotector/Deprotector.cs
@@ -829,7 +829,7 @@ namespace WC3MapDeprotector
                 var mpqFile = MpqFile.New(File.OpenRead(file), shortFileName);
                 mpqFile.CompressionType = MpqCompressionType.ZLib;
                 /* // not supported by War3Net yet
-                if (Path.GetExtension(shortFileName).ToUpper() == ".wav")
+                if (Path.GetExtension(shortFileName).ToUpper() == ".WAV")
                 {
                     mpqFile.CompressionType = MpqCompressionType.Huffman;
                 }
@@ -1580,7 +1580,7 @@ namespace WC3MapDeprotector
         {
             //note: the order of operations matters. For example, script file import fails if info file not yet imported. So we import each file multiple times looking for changes
             _logEvent("Analyzing map files");
-            var mapFiles = Directory.GetFiles(MapFilesPath, "war3map*", SearchOption.AllDirectories).Union(Directory.GetFiles(MapFilesPath, "war3campaign*", SearchOption.AllDirectories)).OrderBy(x => x.ToUpper() == "war3map.w3i" ? 0 : 1).ToList();
+            var mapFiles = Directory.GetFiles(MapFilesPath, "war3map*", SearchOption.AllDirectories).Union(Directory.GetFiles(MapFilesPath, "war3campaign*", SearchOption.AllDirectories)).OrderBy(x => x.ToUpper() == "WAR3MAP.W3i" ? 0 : 1).ToList();
 
             var map = new Map();
             for (var retry = 0; retry < 2; ++retry)


### PR DESCRIPTION
That commit forgot to change the comparisons to be upper-case too

Github Web added the trailing new line...