### PR TITLE
Update build artifact

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -96,7 +96,7 @@ jobs:
         copy Launch_WC3MapDeprotector.bat WC3MapDeprotector\bin\Release
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: WC3MapDeprotector
         path: WC3MapDeprotector\bin\Release


### PR DESCRIPTION
Upload Artifact Version 3 has been depreciated and is causing the current build to fail. I am updating it to version 4.